### PR TITLE
bluetoothctl runs forever on some devices

### DIFF
--- a/haos-sbfspot/rootfs/etc/services.d/sbfspot/run
+++ b/haos-sbfspot/rootfs/etc/services.d/sbfspot/run
@@ -22,11 +22,13 @@ bashio::log.info
 bashio::log.info ${__BASHIO_COLORS_CYAN} "${message:="Hello World..."}"
 bashio::log.info
 
-# ---- Print Host BT Controller
-message=$(echo "[Host Bluetooth MAC Address] $(bluetoothctl list)")
-bashio::log.info
-bashio::log.info ${__BASHIO_COLORS_BLUE} "${message:="Hello World..."}"
-bashio::log.info
+if  bashio::var.equals "${value}" "Bluetooth"; then
+   # ---- Print Host BT Controller
+   message=$(echo "[Host Bluetooth MAC Address] $(bluetoothctl list)")
+   bashio::log.info
+   bashio::log.info ${__BASHIO_COLORS_BLUE} "${message:="Hello World..."}"
+   bashio::log.info
+fi
 
 #set -x
 


### PR DESCRIPTION
Apparently bluetoothctl makes this scipt to hang. I was first using this addon on HAOS, where it ran without issues. Than I migrated to HA supervised, where it did not start, it just printed the output of the uname command then waited forever. With this proposed change the Bluetooth address will be printed only when Bluetooth is configured (vs Ethernet).