### PR TITLE
Add pvoSID example to sbfspot README

### DIFF
--- a/sbfspot/README.md
+++ b/sbfspot/README.md
@@ -52,6 +52,10 @@ mqtt_pass: ""
 home_lat: ""
 home_long: ""
 Timezone: ""
+
+# Map inverters to PVoutput System ID's
+# PVoutput_SID=SerialNmbrInverter_1:PVoutput_System_ID_1,SerialNmbrInverter_2:PVoutput_System_ID_2
+# e.g. PVoutput_SID=200212345:4321
                              ### IF YOU WANT TO SKIP PVoutput
 pvoSID: "0123456789:12345"   ### will default to fake if left empty
 pvoAPIkey: "fake9364fake4545afke834fake"   ### will default to fake if left empty


### PR DESCRIPTION
Because I've been struggling with not being able to upload anything to pvoutput.org - while I even copy and pasted the System ID from the website to the configuration to not mix up any numbers - I looked into the source code and found better instructions in the file `sbfspot/rootfs/usr/bin/sbfspot/SBFspotUpload.default.cfg`. This is why I copy and pasted them into the README, so that other people don't need to struggle to understand what the numbers before the `:` in the example mean.